### PR TITLE
[RFC] Adds ability to customise AWS region

### DIFF
--- a/lib/fastboot-lambda-deploy-plugin.js
+++ b/lib/fastboot-lambda-deploy-plugin.js
@@ -3,13 +3,13 @@ var glob             = require('glob');
 var path             = require('path');
 var RSVP             = require('rsvp');
 var AWS              = require('aws-sdk');
-var Lambda           = new AWS.Lambda({ region: 'us-east-1' });
-var UpdateLambdaFunc = RSVP.denodeify(Lambda.updateFunctionCode.bind(Lambda));
 var exec             = RSVP.denodeify(require('child_process').exec);
 var DeployPlugin     = require('ember-cli-deploy-plugin');
 
 module.exports = DeployPlugin.extend({
-
+  defaultConfig: {
+      region: 'us-east-1'
+  },
   requiredConfig: ['lambda-function'],
 
   didBuild: function(context) {
@@ -36,6 +36,10 @@ module.exports = DeployPlugin.extend({
   activate: function(context) {
     var self = this;
     var lambdaFunction = this.readConfig('lambda-function');
+    var region = this.readConfig('region');
+
+    var Lambda = new AWS.Lambda({ region: region });
+    var UpdateLambdaFunc = RSVP.denodeify(Lambda.updateFunctionCode.bind(Lambda));
 
     this.log('zipping up tmp/lambda-package', { verbose: true });
     return exec("zip -qr lambda-package.zip *", { cwd: 'tmp/lambda-package' })


### PR DESCRIPTION
**Why?**
Depending on where your business needs are, different companies need to be able to serve their ember apps from different region than us-east-1.

**What does this PR do in a nutshell?**
This PR adds an extra `region` config key in the ember deploy configuration which allows for passing in custom regions. It follows the `ember-cli-deploy-plugin` spec for defaulting to `us-east-1` for backwards compatibility with anyone using this plugin currently.

Closes #4 